### PR TITLE
使用File.separator替代"\\"以解决跨系统兼容性问题

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,6 +1,6 @@
 name: ResidenceForm 自动构建
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ltd.rymc</groupId>
     <artifactId>ResidenceForm</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
     <packaging>jar</packaging>
 
     <name>ResidenceForm</name>

--- a/src/main/java/ltd/rymc/form/residence/serialiser/AbstractLanguageSerialiser.java
+++ b/src/main/java/ltd/rymc/form/residence/serialiser/AbstractLanguageSerialiser.java
@@ -9,6 +9,7 @@ import space.arim.dazzleconf.serialiser.Decomposer;
 import space.arim.dazzleconf.serialiser.FlexibleType;
 import space.arim.dazzleconf.serialiser.ValueSerialiser;
 
+import java.io.File;
 import java.util.List;
 
 public abstract class AbstractLanguageSerialiser implements ValueSerialiser<Language> {

--- a/src/main/java/ltd/rymc/form/residence/serialiser/AbstractLanguageSerialiser.java
+++ b/src/main/java/ltd/rymc/form/residence/serialiser/AbstractLanguageSerialiser.java
@@ -36,7 +36,7 @@ public abstract class AbstractLanguageSerialiser implements ValueSerialiser<Lang
     @Override
     public Language deserialise(FlexibleType flexibleType) throws BadValueException {
         String language = getValue(flexibleType);
-        ConfigManager<?> configManager = ResourceConfigManager.create(ResidenceForm.getInstance(), language, "lang\\" + language + ".yml", getTargetConfig());
+        ConfigManager<?> configManager = ResourceConfigManager.create(ResidenceForm.getInstance(), language, "lang" + File.separator + language + ".yml", getTargetConfig());
         configManager.reloadConfig();
         return Language.of(configManager, getTargetConfig());
     }


### PR DESCRIPTION
use File.separator instead of using `\\ ` .
 `\\` only support windows.